### PR TITLE
Allowed button-style post terms to wrap.

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -482,6 +482,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 .is-style-buttons.wp-block-post-terms {
 	display: flex;
 	gap: 0.3rem;
+	flex-wrap: wrap;
 }
 .is-style-buttons.wp-block-post-terms > a {
 	display: inline-block;


### PR DESCRIPTION
Button-style post terms do not wrap. This PR fixes that.

Screenshot of before the change:

![Screenshot 2022-02-28 at 11-17-28 Edge Case Many Tags – Local Site](https://user-images.githubusercontent.com/613931/156028247-5e8178e5-6f90-4cab-8d5a-ffd2fb856742.png)

After:
![Screenshot 2022-02-28 at 11-19-11 Edge Case Many Tags – Local Site](https://user-images.githubusercontent.com/613931/156028441-7a1a5d27-5737-4273-a33b-90efcd20c1eb.png)

