### PR TITLE
Fixed close menu button color.

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -548,7 +548,7 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
         color: var(--wp--custom--color--hero-text, #000000);
 }
 
-.wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open {
+.single-post .wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open {
 	color: var(--wp--custom--color--hero-text, #000000);
 }
 

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -548,6 +548,10 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
         color: var(--wp--custom--color--hero-text, #000000);
 }
 
+.wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open {
+	color: var(--wp--custom--color--hero-text, #000000);
+}
+
 /*
  * Footer.
  */


### PR DESCRIPTION
This PR addresses an issue with the "close menu" button color where the color doesn't follow the header text color.

To replicate the issue:
1. In the site editor, open the Styles panel and switch to the dark mode theme.
2. Open the site and visit a blog post in a narrow enough width to show the menu button.
3. Click the menu button and observe that the close menu button color is black, not white.

Screenshot of the problem:
![Screenshot 2022-03-17 at 10-44-40 Hello world! – Local Site](https://user-images.githubusercontent.com/613931/158838924-2384055a-0861-4d35-ac81-02fd1f7384cd.png)

The issue is that the Gutenberg block library stylesheet has a pretty high specificity style setting the color to `#000`. As far as I can tell, it takes an equally high specificity style in `theme.css` to override it.
