### PR TITLE
Add pattern markup, instead of pattern blocks

### DIFF
--- a/inc/patterns/header-accent-w-button.php
+++ b/inc/patterns/header-accent-w-button.php
@@ -5,7 +5,6 @@
 return array(
 	'title'      => __( 'Header, accent color with button', 'wabi' ),
 	'categories' => array( 'wabi', 'header' ),
-	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '
 		<!-- wp:group {"align":"full", "backgroundColor":"accent","layout":{"inherit":true}} -->
 		<div class="wp-block-group alignfull has-accent-background-color has-background"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-accent.php
+++ b/inc/patterns/header-accent.php
@@ -5,7 +5,6 @@
 return array(
 	'title'      => __( 'Header, accent color', 'wabi' ),
 	'categories' => array( 'wabi', 'header' ),
-	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '
 		<!-- wp:group {"align":"full", "backgroundColor":"accent","layout":{"inherit":true}} -->
 		<div class="wp-block-group alignfull has-accent-background-color has-background"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/inc/patterns/header-w-button.php
+++ b/inc/patterns/header-w-button.php
@@ -5,7 +5,6 @@
 return array(
 	'title'      => __( 'Header with button', 'wabi' ),
 	'categories' => array( 'wabi', 'header' ),
-	'blockTypes' => array( 'core/template-part/header' ),
 	'content'    => '
 		<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
 		<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
@@ -24,7 +23,7 @@ return array(
 		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
 		<div class="wp-block-group">
 
-		<!-- wp:navigation {"overlayTextColor":"foreground","overlayBackgroundColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+		<!-- wp:navigation {"overlayTextColor":"foreground","overlayBackgroundColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}},"style":{"spacing":{"blockGap":"1.5rem"}}} -->
 		<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 		<!-- /wp:navigation -->
 

--- a/parts/header-accent-w-button.html
+++ b/parts/header-accent-w-button.html
@@ -1,1 +1,45 @@
-<!-- wp:pattern {"slug":"wabi/header-accent-w-button"} /-->
+<!-- wp:group {"align":"full", "backgroundColor":"accent","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-accent-background-color has-background">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignfull"
+		style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)">
+		<!-- wp:group {"layout":{"type":"flex"}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-logo {"width":48,"className":"is-style-rounded"} /-->
+			<!-- wp:site-title {"textColor":"accent-alt"} /-->
+
+			<!-- wp:social-links {"iconColor":"accent-alt","iconColorValue":"var(--wp--custom--color--hero-text)","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.75rem"}}} -->
+			<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
+				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"wordpress"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"github"} /-->
+			</ul>
+			<!-- /wp:social-links -->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+
+			<!-- wp:navigation {"textColor":"accent-alt","overlayBackgroundColor":"accent","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+			<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+			<!-- /wp:navigation -->
+
+			<!-- wp:buttons -->
+			<div class="wp-block-buttons">
+				<!-- wp:button {"style":{"spacing":{"padding":{"top":"0.5rem","bottom":"0.5rem","left":"0.85rem","right":"0.85rem"}}},"fontSize":"small"} -->
+				<div class="wp-block-button has-custom-font-size has-small-font-size"><a
+						class="wp-block-button__link"
+						style="padding-top:0.5rem;padding-right:0.85rem;padding-bottom:0.5rem;padding-left:0.85rem">Follow</a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/parts/header-accent.html
+++ b/parts/header-accent.html
@@ -1,1 +1,36 @@
-<!-- wp:pattern {"slug":"wabi/header-accent"} /-->
+<!-- wp:group {"align":"full", "backgroundColor":"accent","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-accent-background-color has-background">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignfull"
+		style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)">
+		<!-- wp:group {"layout":{"type":"flex"}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-logo {"width":48,"className":"is-style-rounded"} /-->
+			<!-- wp:site-title {"textColor":"accent-alt"} /-->
+
+			<!-- wp:social-links {"iconColor":"accent-alt","iconColorValue":"var(--wp--custom--color--hero-text)","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.75rem"}}} -->
+			<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
+				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"wordpress"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"github"} /-->
+			</ul>
+			<!-- /wp:social-links -->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+
+			<!-- wp:navigation {"textColor":"accent-alt","overlayBackgroundColor":"accent","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+			<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+			<!-- /wp:navigation -->
+
+			<!-- wp:search {"label":"","showLabel":false,"placeholder":"Search…","width":150,"widthUnit":"px","buttonText":"Search","buttonPosition":"no-button","style":{"border":{"width":"0rem","style":"none","radius":"12px"}},"className":"hide-on-mobile"} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/parts/header-w-button.html
+++ b/parts/header-w-button.html
@@ -1,1 +1,45 @@
-<!-- wp:pattern {"slug":"wabi/header-w-button"} /-->
+<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--small, 1.25rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignfull"
+		style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)">
+		<!-- wp:group {"layout":{"type":"flex"}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-logo {"width":48,"className":"is-style-rounded"} /-->
+			<!-- wp:site-title {"textColor":"accent-alt"} /-->
+
+			<!-- wp:social-links {"size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.75rem"}}} -->
+			<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
+				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"wordpress"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"github"} /-->
+			</ul>
+			<!-- /wp:social-links -->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+
+			<!-- wp:navigation {"overlayTextColor":"foreground","overlayBackgroundColor":"background","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+			<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+			<!-- /wp:navigation -->
+
+			<!-- wp:buttons -->
+			<div class="wp-block-buttons">
+				<!-- wp:button {"style":{"spacing":{"padding":{"top":"0.5rem","bottom":"0.5rem","left":"0.85rem","right":"0.85rem"}}},"fontSize":"small"} -->
+				<div class="wp-block-button has-custom-font-size has-small-font-size"><a
+						class="wp-block-button__link"
+						style="padding-top:0.5rem;padding-right:0.85rem;padding-bottom:0.5rem;padding-left:0.85rem">Follow</a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->


### PR DESCRIPTION
Remove the use of the core pattern block, as those do not render when replacing template parts. I also remove the `array( 'core/template-part/header' ),` blockTypes from the header patterns, as they show up within template parts and patterns when replacing. 

Before:
<img width="976" alt="mo" src="https://user-images.githubusercontent.com/1813435/173077024-55c4fb1f-0df5-4268-889b-5ae7b895dd14.png">

After: 
<img width="952" alt="CleanShot 2022-06-10 at 09 32 30@2x" src="https://user-images.githubusercontent.com/1813435/173077048-227148fa-15de-4fbf-a280-be2a79830e12.png">
 